### PR TITLE
Ignore $slots at render time when $slots.default is empty

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export default {
     this.mediaQueryList.addListener(this.updateMatches)
   },
   render() {
-    if (this.matches) {
+    if (this.matches && this.$slots.default && this.$slots.default.length > 0) {
       return this.$slots.default[0]
     }
   },


### PR DESCRIPTION
In reference to [issue #6](https://github.com/egoist/vue-media/issues/6)