### PR TITLE
add Array type to query props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const Media = {
   name: 'media',
   props: {
     query: {
-      type: [Object, String],
+      type: [Object, String, Array],
       required: true
     },
     visibleByDefault: {


### PR DESCRIPTION
`jsonmq` supports type 'Array' as query' such as

```javascript
json2mq([{screen: true, minWidth: 100}, {handheld: true, orientation: 'landscape'}]); 
```